### PR TITLE
chore: add build step before running tests. closes #70

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "cover": "nyc npm t && npm run coverage-report",
     "coverage-check": "nyc check-coverage --branches 100 --statements 100 --functions 100 --lines 100",
     "coverage-report": "nyc report --reporter=lcov",
-    "test": "_mocha --compilers js:babel-register",
+    "test": "npm run build && _mocha --compilers js:babel-register",
     "prebuild": "rimraf dist",
     "build": "babel --copy-files --out-dir dist src",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
Build before running tests so they can run without error if no build has created the dist/ directory. Also ensures that the most up to date version of the build is being tested