### PR TITLE
verify that passing a falsy value as the parser value

### DIFF
--- a/test/main.spec.js
+++ b/test/main.spec.js
@@ -138,6 +138,13 @@ const setupPullerTests = (C, name) => {
       })
 
       describe('Wrapper:_createParseTunnel', () => {
+        it('should not parse falsy', () => {
+          const _puller = cloneDeep(puller)
+          _puller._parsers['Entry'] = false
+          const parsed = _puller._createParseTunnel(_puller)(cloneDeep(data.unparsed))
+          parsed.should.deep.equal(data.unparsed)
+        })
+
         it('should parse a single object', () => {
           const parsed = puller._createParseTunnel(puller)(cloneDeep(data.unparsed))
           parsed.should.deep.equal(data.parsed)


### PR DESCRIPTION
resolves #69

The line 
```
if (o && o.sys && o.sys.type && $this._parsers[o.sys.type] && done.indexOf(o) === -1) {
```
evals to false if you pass a falsy value as the value for the key `$this._parsers[o.sys.type]` The test verifies this is so. It will return the passed object unparsed which is what issue #69 requested